### PR TITLE
Fix missing publication cover image for JPCL Mössbauer paper

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -275,6 +275,7 @@ selected={False}
 }
 
 @article{yang2026jpclett,
+  preview={jpclett-5c03985-cover.png},
   title={Data-Driven Deciphering Structure--M{\"o}ssbauer Spectroscopy Relationships in Iron-Based Compounds},
   author={Yang, Tao and Zhang, Jiaqing and Chen, Haotian and Yuan, Xiaoze and Zhou, Yuwei and Guo, Wenping and Liu, Xingchen and Liu, Xiaotong and Liu, Jinjia},
   journal={The Journal of Physical Chemistry Letters},


### PR DESCRIPTION
### Motivation
- Ensure the JPCL paper "Data-Driven Deciphering Structure--Mössbauer Spectroscopy Relationships in Iron-Based Compounds" shows its publication thumbnail in the publications list by providing the missing preview filename.

### Description
- Added `preview={jpclett-5c03985-cover.png}` to the `yang2026jpclett` BibTeX entry in `_bibliography/papers.bib` so the site will load the image from `assets/img/publication_preview/`.

### Testing
- Verified the change is present with `rg -n "yang2026jpclett|jpclett-5c03985-cover.png" _bibliography/papers.bib`; attempted `bundle exec jekyll build` and `bundle install` to validate a full build but the environment failed dependency installation/build due to a Bundler network `403 Forbidden` and missing `jekyll` executable, so only the file-level verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698afb1dbf48832fbf6daa844fddae74)