### PR TITLE
Update UG present page profile image to 2026bishe.jpg

### DIFF
--- a/_pages/profiles_ug_present.md
+++ b/_pages/profiles_ug_present.md
@@ -10,7 +10,7 @@ profiles:
   # if you want to include more than one profile, just replicate the following block
   # and create one content file for each profile inside _pages/
   - align: right
-    image: man_default.png
+    image: people_pics/2026bishe.jpg
     content: people/2026_bishe.md
     image_circular: false # crops the image to make it circular
     more_info: >


### PR DESCRIPTION
### Motivation
- Replace the placeholder profile image on the `/people_ug_present/` page with the newly uploaded photo so the page shows the correct student portrait.

### Description
- Update `_pages/profiles_ug_present.md` by changing `image: man_default.png` to `image: people_pics/2026bishe.jpg` and commit the change (commit message: `Update UG present profile image to 2026bishe`).

### Testing
- Verified the change with `git diff -- _pages/profiles_ug_present.md` and `git status --short`, and attempted `bundle exec jekyll serve` but `bundle install` failed due to a `403 Forbidden` when fetching gems so a local Jekyll preview could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae6f9a98b0832fbf42467ba822941a)