### PR TITLE
Add Liu et al. 2026 review to bibliography

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,5 +1,21 @@
 @string{aps = {American Physical Society,}}
 
+@article{liu2026cmt,
+  preview={computational_materials_today_2026.jpg},
+  title={A review of topological descriptors for amorphous materials complementing graph neural networks},
+  author={Wang, Yuhang and Guo, Dongchao and Yang, Tao and Qian, Qihao and Liu, Xiaotong and Shi, Siqi},
+  journal={Computational Materials Today},
+  year={2026},
+  pages={100053},
+  issn={2950-4635},
+  doi={https://doi.org/10.1016/j.commt.2026.100053},
+  url={https://doi.org/10.1016/j.commt.2026.100053},
+  html={https://www.sciencedirect.com/science/article/pii/S2950463526000086?via%3Dihub},
+  abstract={Amorphous systems lack long-range order, making their properties strongly dependent on short-range order (SRO) and medium-range order (MRO) structural motifs and their network connectivity. While graph neural networks (GNNs) excel for crystalline materials, their performance on amorphous systems is limited by graph construction ambiguities, message-passing bottlenecks, data scarcity, and transferability issues. This review surveys traditional descriptors and then focuses on topological approaches: complex network descriptors, persistent homology, rigidity theory (also known as topological constraint theory), and graph limit metrics. We summarize how rings, voids, and percolating backbones correlate with mechanics, transport, and thermodynamics across metallic glasses, oxide glasses, polymers, and organic semiconductors, among others, highlighting their potential to inform the exploration and design of amorphous energy materials. Finally, we provide a shortlist of topological variables with potential for property modeling and set out three directions in datasets, unified topology modeling and topology aware GNN architectures.},
+  keywords={Topological descriptors, Complex network, Persistent homology, Amorphous materials, GNN},
+  selected={false}
+}
+
 @article{https://doi.org/10.1002/adfm.202519233,
 preview={afm.png},
 author = {Yuan, Yifeng and Wang, Jie and Yang, Aoci and Liu, Xiaotong and Yang, Xuan and Li, Zhaolin and Xiao, Biwei and Zhao, Hailei},


### PR DESCRIPTION
### Motivation
- Add a new bibliography entry for a 2026 review on topological descriptors for amorphous materials to provide a citation and metadata for related content.

### Description
- Inserted a new `@article` entry `liu2026cmt` into `_bibliography/papers.bib` containing DOI, URL, abstract, keywords, preview image, and full bibliographic metadata.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5c1131b30832fb3ec1acc0007f2fc)