### PR TITLE
Update homepage subtitle to College of Computer Science

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,7 +2,7 @@
 layout: about
 title: About
 permalink: /
-subtitle: echo nc.ude.utsib@gnotoaixuil|rev, <a href='https://jsjxy.bistu.edu.cn/'>School of Computer</a>, <a href='https://www.bistu.edu.cn/'>Beijing Information Science and Technology University</a>
+subtitle: echo nc.ude.utsib@gnotoaixuil|rev, <a href='https://jsjxy.bistu.edu.cn/'>College of Computer Science</a>, <a href='https://www.bistu.edu.cn/'>Beijing Information Science and Technology University</a>
 
 profile:
   align: right


### PR DESCRIPTION
### Motivation
- The homepage subtitle referenced `School of Computer` and needs to be updated to the new official name `College of Computer Science`.

### Description
- In `_pages/about.md` replaced the subtitle text `School of Computer` with `College of Computer Science` while keeping the existing link unchanged.

### Testing
- Verified the edit with `git diff -- _pages/about.md` and attempted `bundle exec jekyll build --quiet`, where the build failed due to the environment missing the `jekyll` executable from Bundler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcb3848d0832f949064646789a9e2)