### PR TITLE
Add 2026 Guangzhou AI+新材料 conference gallery entry and image folders

### DIFF
--- a/_projects/10_project.md
+++ b/_projects/10_project.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: 首届中国“AI+新材料”大会
+description: 2026年4月9-12日 广东 广州
+img: assets/img/template_error.png
+importance: 1
+category: work
+related_publications: false
+images:
+  lightbox2: true
+  photoswipe: true
+  spotlight: true
+  venobox: true
+---
+
+2026年4月9-12日，应邀参加首届中国“AI+新材料”大会，并在论坛一和论坛十三分别作邀请报告。
+
+## 大会照片（点击图片放大）
+
+待上传...

--- a/assets/img/2026guangzhou/.gitkeep
+++ b/assets/img/2026guangzhou/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder for 2026 Guangzhou conference images

--- a/assets/img/2026guangzhou/thumbs/.gitkeep
+++ b/assets/img/2026guangzhou/thumbs/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder for 2026 Guangzhou thumbnail images


### PR DESCRIPTION
### Motivation
- Prepare the site to host photos from the 首届中国“AI+新材料”大会 (2026-04-09 — 2026-04-12, Guangzhou) and record that invited talks were given in Forum I and Forum XIII.

### Description
- Created image directories `assets/img/2026guangzhou/` and `assets/img/2026guangzhou/thumbs/` and added `.gitkeep` placeholders so the folders are tracked before images are uploaded.
- Added a new Gallery `work` entry at `_projects/10_project.md` with metadata (title, dates, location, category) and a short description noting the invited reports in Forum I and Forum XIII.
- Used `assets/img/template_error.png` as a temporary `img:` thumbnail and left a body placeholder (`待上传...`) for the photos to be uploaded later.
- Files added: `/_projects/10_project.md`, `assets/img/2026guangzhou/.gitkeep`, and `assets/img/2026guangzhou/thumbs/.gitkeep`.

### Testing
- Ran `git diff --check`, which reported no issues.
- Ran `git status --short` to verify the working tree state, which showed no outstanding changes after the updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0a370b84832fb07e98c4fa6d16db)