### PR TITLE
Update Guangzhou 2026 project gallery and cover image

### DIFF
--- a/_projects/10_project.md
+++ b/_projects/10_project.md
@@ -2,7 +2,7 @@
 layout: post
 title: 首届中国“AI+新材料”大会
 description: 2026年4月9-12日 广东 广州
-img: assets/img/template_error.png
+img: assets/img/2026guangzhou/thumbs/4.jpg
 importance: 1
 category: work
 related_publications: false
@@ -17,4 +17,11 @@ images:
 
 ## 大会照片（点击图片放大）
 
-待上传...
+<a href="../../assets/img/2026guangzhou/1.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/1.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/2.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/2.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/3.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/3.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/4.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/4.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/5.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/5.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/6.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/6.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/7.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/7.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/8.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/8.jpg" /></a>


### PR DESCRIPTION
### Motivation
- The project page had a placeholder gallery and a missing/placeholder cover image which prevented the Guangzhou 2026 photos from displaying correctly.
- Replace the placeholder with the actual images and set a proper cover thumbnail so the project card and gallery render as intended.

### Description
- Modified `_projects/10_project.md` to set the cover image to `assets/img/2026guangzhou/thumbs/4.jpg`.
- Replaced the `待上传...` placeholder with eight lightbox gallery entries that link to `../../assets/img/2026guangzhou/1.jpg` through `../../assets/img/2026guangzhou/8.jpg` and their matching thumbnail paths.
- Used the existing `data-lightbox="roadtrip"` markup so the gallery integrates consistently with the site's lightbox setup.

### Testing
- Ran a scripted replacement to update `_projects/10_project.md` and inspected the file with `sed -n '1,240p' _projects/10_project.md` and `nl -ba _projects/10_project.md` to confirm the changes were applied.
- Verified the image files exist with `find assets/img/2026guangzhou -maxdepth 2 -type f` and confirmed matching thumbnail files under `assets/img/2026guangzhou/thumbs/`.
- Generated a diff for the edited file with `git diff -- _projects/10_project.md` to review the precise modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0ee6965c832f89f0c206c1f147a9)