### PR TITLE
Move 郑丹妮 from master present to master alumni

### DIFF
--- a/_pages/profiles_master_alumni.md
+++ b/_pages/profiles_master_alumni.md
@@ -28,4 +28,10 @@ profiles:
     more_info: >
       <p>计研2203, 2022020654@bistu.edu.cn</p>
       <p>与杨涛老师合作指导</p>
+  - align: left
+    image: people_pics/zdn_profile_picture.png
+    content: people/zdn_profile.md
+    image_circular: false # crops the image to make it circular
+    more_info: >
+      <p>计研2403</p>
 ---

--- a/_pages/profiles_master_present.md
+++ b/_pages/profiles_master_present.md
@@ -29,12 +29,6 @@ profiles:
     more_info: >
       <p>计研2401, 554693230@qq.com</p>
       <p>与杨涛老师合作指导</p>
-  - align: right
-    image: people_pics/zdn_profile_picture.png
-    content: people/zdn_profile.md
-    image_circular: false # crops the image to make it circular
-    more_info: >
-      <p>计研2403</p>
   - align: left
     image: people_pics/lsb_profile_picture.png
     content: people/lsb_profile.md


### PR DESCRIPTION
### Motivation
- 郑丹妮已毕业，应从在读硕士页面转移到已毕业硕士页面以保持人员列表准确。  

### Description
- Removed the `people/zdn_profile.md` entry from `_pages/profiles_master_present.md` and added the same `people/zdn_profile.md` entry to `_pages/profiles_master_alumni.md`, keeping the `计研2403` more_info and image reference unchanged.  

### Testing
- Attempted to run `bundle exec jekyll build --quiet` to validate the site build but it failed with `bundler: command not found: jekyll`, so no successful build verification was completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df09b46d78832fa244199ebe392787)