### PR TITLE
修复硕士生页面头像左右交替布局

### DIFF
--- a/_pages/profiles_master_alumni.md
+++ b/_pages/profiles_master_alumni.md
@@ -21,14 +21,14 @@ profiles:
     image_circular: false # crops the image to make it circular
     more_info: >
       <p>成为硕导前合作过的硕士生，由于种种原因没能一起走到最后，道一声“抱歉”，送上祝福</p>
-  - align: right
+  - align: left
     image: people_pics/wzm_profile_picture.png
     content: people/wzm_profile.md
     image_circular: false # crops the image to make it circular
     more_info: >
       <p>计研2203, 2022020654@bistu.edu.cn</p>
       <p>与杨涛老师合作指导</p>
-  - align: left
+  - align: right
     image: people_pics/zdn_profile_picture.png
     content: people/zdn_profile.md
     image_circular: false # crops the image to make it circular

--- a/_pages/profiles_master_present.md
+++ b/_pages/profiles_master_present.md
@@ -29,31 +29,31 @@ profiles:
     more_info: >
       <p>计研2401, 554693230@qq.com</p>
       <p>与杨涛老师合作指导</p>
-  - align: left
+  - align: right
     image: people_pics/lsb_profile_picture.png
     content: people/lsb_profile.md
     image_circular: false # crops the image to make it circular
     more_info: >
       <p>计研2404, 763568748@qq.com</p>
-  - align: right
+  - align: left
     image: people_pics/ykl_profile_picture.png
     content: people/ykl_profile.md
     image_circular: false # crops the image to make it circular
     more_info: >
       <p>计研2504, 1274853269@qq.com</p>
-  - align: left
+  - align: right
     image: people_pics/fq_profile_picture.png
     content: people/fq_profile.md
     image_circular: false # crops the image to make it circular
     more_info: >
       <p>计研2504, 2572443758@qq.com</p>
-  - align: right
+  - align: left
     image: people_pics/zdxl_profile_picture.png
     content: people/zdxl_profile.md
     image_circular: false # crops the image to make it circular
     more_info: >
       <p>计研2505, 1571203446@qq.com</p>
-  - align: left
+  - align: right
     image: people_pics/zjm_profile_picture.png
     content: people/zjm_profile.md
     image_circular: false # crops the image to make it circular


### PR DESCRIPTION
### Motivation
- 在把郑丹妮从“在读”移到“已毕业”后，两个硕士页面出现相邻卡片同侧对齐（左左或右右），破坏了原本的左右交替视觉效果。

### Description
- 修改了 `_pages/profiles_master_present.md`，调整每个 `- align:` 为严格交替的 `left` / `right` 序列以恢复上下交替布局。 
- 修改了 `_pages/profiles_master_alumni.md`，调整 `- align:` 值使毕业页同样保持严格交替，并相应调整了相关条目的对齐。 
- 本次变更仅涉及两个文件：`_pages/profiles_master_present.md` 和 `_pages/profiles_master_alumni.md`。

### Testing
- 运行了一个小脚本（`python - <<'PY' ... PY`）解析两个文件中所有 `- align:` 行并检查相邻条目是否交替，结果两页均返回 `alternating=True`，测试通过。 
- 手动检查了更新后的 `- align:` 列表以确认每一对相邻条目均为左右交替，确认无误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0d58a510832fb5174b12c7ccfdc8)