### PR TITLE
Add 9th Guangzhou conference photo to project page

### DIFF
--- a/_projects/10_project.md
+++ b/_projects/10_project.md
@@ -26,3 +26,4 @@ images:
 <a href="../../assets/img/2026guangzhou/6.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/6.jpg" /></a>
 <a href="../../assets/img/2026guangzhou/7.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/7.jpg" /></a>
 <a href="../../assets/img/2026guangzhou/8.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/8.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/9.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/9.jpg" /></a>


### PR DESCRIPTION
### Motivation
- Include the newly uploaded conference photo `assets/img/2026guangzhou/9.jpg` (and its thumbnail) in the project gallery so it appears on the project page.

### Description
- Updated ` _projects/10_project.md` to append a gallery entry linking `../../assets/img/2026guangzhou/9.jpg` with thumbnail `../../assets/img/2026guangzhou/thumbs/9.jpg`.

### Testing
- No automated tests were run for this content-only markdown/gallery update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a513643c832fbd514895e8c78380)