### PR TITLE
Add gallery/work album for 2023 UCLouvain PhD defense (Yuqing He)

### DIFF
--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -57,7 +57,7 @@ nav_order: 4
     * 11月：指导软工2103班苏拜提江·阿不都拉，贾乙，倪芊睿参加“2023年勤信数智人工智能应用大赛决赛名单-赛事A”，以第9名成绩进入决赛（全校本硕预赛前15名进入决赛，唯一本科生团队）
   * 研究生：
     * 6月：行业前沿讲座
-  * 12月7日: [在比利时 UCLouvain 大学担任 Yuqing He 博士毕业答辩委员会成员](https://cdn.uclouvain.be/groups/cms-editors-sst/affiche-soutenance-publique-de-these-(jpeg)/Affiche%20annonce%20de%20these%20HE%20Yuqing%20corrig%C3%A9e_0.pdf)
+  * 12月7日: 在比利时 UCLouvain 大学担任 Yuqing He 博士毕业答辩委员会成员（详情见 [gallery/work 专题相册](/gallery/)）
 * `2022`
   * 本科生：
     * 软工2103班主任

--- a/_projects/11_project.md
+++ b/_projects/11_project.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: UCLouvain 博士毕业答辩委员会（Yuqing He）
+description: 2023年12月7日 比利时 Louvain-la-Neuve
+event_date: 2023-12-07
+importance: 1
+category: work
+related_publications: false
+images:
+  lightbox2: true
+---
+
+2023年12月7日，我在比利时 UCLouvain（Université catholique de Louvain）担任 Yuqing He 博士毕业答辩委员会成员。
+
+根据 UCLouvain 官方学术数据库 DIAL 记录，本次博士论文题目为 *Machine Learning topological characteristics from multiple electronic materials databases*，答辩日期为 **07/12/2023**，导师为 Gian-Marco Rignanese 与 Matteo Giantomassi。
+
+## 相关资料
+
+- 论文记录（DIAL）：[Machine Learning topological characteristics from multiple electronic materials databases](https://dial.uclouvain.be/pr/boreal/object/boreal%3A284193)
+- 答辩海报（UCLouvain）：[Affiche annonce de these HE Yuqing](https://cdn.uclouvain.be/groups/cms-editors-sst/affiche-soutenance-publique-de-these-(jpeg)/Affiche%20annonce%20de%20these%20HE%20Yuqing%20corrig%C3%A9e_0.pdf)


### PR DESCRIPTION
### Motivation

- 将教学页中提到的 2023-12-07 UCLouvain 答辩事件整理为专题相册，以便在 `gallery/work` 分类下集中展示图片与说明。 
- 在相册中补充该次答辩的元信息（论文题目、答辩日期、导师等）并保留对外证据链接，便于读者查阅原始资料。

### Description

- 新增 `
_projects/11_project.md
`，包含页面元数据（`layout`, `title`, `description`, `event_date`, `category` 等）以及事件说明、UCLouvain DIAL 记录与答辩海报链接。 
- 修改 `
_pages/teaching.md
` 中对应 2023 年条目， 将原始外部海报链接替换为指向专题相册的交叉引用（文本指引到 `/gallery/`），以减少信息重复并引导到新相册。 
- 尝试在仓库下创建图片目录并下载答辩海报用于本地展示，但外部下载因远程访问被拒绝（403），因此保留海报为外部链接而未将二进制文件加入仓库。 

### Testing

- 运行 `bundle exec jekyll build --quiet` 以检查站点能否构建，结果失败因为当前环境缺少 `jekyll` 可执行（`bundler: command not found: jekyll`）。
- 运行 `git diff --check HEAD~1 HEAD` 检查文件差异与空格问题，未发现问题且命令成功退出。 
- 运行 `git status --short` 确认工作区变更（新增 `
_projects/11_project.md
`，修改 `
_pages/teaching.md
`）已就绪。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37613bf34832f8d2ace7b6c8ff5ae)