### PR TITLE
Add 2023yuqing image folder and gallery to project 11 page

### DIFF
--- a/_projects/11_project.md
+++ b/_projects/11_project.md
@@ -3,16 +3,30 @@ layout: post
 title: UCLouvain 博士毕业答辩委员会（Yuqing He）
 description: 2023年12月7日 比利时 Louvain-la-Neuve
 event_date: 2023-12-07
+img: assets/img/2023yuqing/1.jpg
 importance: 1
 category: work
 related_publications: false
 images:
   lightbox2: true
+  photoswipe: true
+  spotlight: true
+  venobox: true
 ---
 
 2023年12月7日，我在比利时 UCLouvain（Université catholique de Louvain）担任 Yuqing He 博士毕业答辩委员会成员。
 
 根据 UCLouvain 官方学术数据库 DIAL 记录，本次博士论文题目为 *Machine Learning topological characteristics from multiple electronic materials databases*，答辩日期为 **07/12/2023**，导师为 Gian-Marco Rignanese 与 Matteo Giantomassi。
+
+## 现场照片（点击图片放大）
+
+<a href="../../assets/img/2023yuqing/1.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2023yuqing/1.jpg" /></a>
+<a href="../../assets/img/2023yuqing/2.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2023yuqing/2.jpg" /></a>
+<a href="../../assets/img/2023yuqing/3.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2023yuqing/3.jpg" /></a>
+<a href="../../assets/img/2023yuqing/4.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2023yuqing/4.jpg" /></a>
+<a href="../../assets/img/2023yuqing/5.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2023yuqing/5.jpg" /></a>
+<a href="../../assets/img/2023yuqing/6.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2023yuqing/6.jpg" /></a>
+<a href="../../assets/img/2023yuqing/7.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2023yuqing/7.jpg" /></a>
 
 ## 相关资料
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated gallery for the 2023 Yuqing photos so the `11_project` page can display the photos in the same style as other project pages.
- Ensure image filenames follow the existing convention (`1.jpg`, `2.jpg`, …) so uploads will work without further template changes.

### Description
- Create the image folder `assets/img/2023yuqing/` and include a placeholder `.gitkeep` so the directory is tracked.
- Update `_projects/11_project.md` to set the cover image to `assets/img/2023yuqing/1.jpg` in the front matter.
- Enable gallery/viewer options in the front matter by adding `photoswipe`, `spotlight`, and `venobox` in addition to `lightbox2`.
- Add seven image entries in the page body that reference `../../assets/img/2023yuqing/1.jpg` through `../../assets/img/2023yuqing/7.jpg` so the gallery will work once images are uploaded.

### Testing
- Verified the updated page contents by printing the file with `nl -ba _projects/11_project.md` and confirming the new `img` field, gallery options, and seven image links are present.
- Created the directory with `mkdir -p assets/img/2023yuqing && touch assets/img/2023yuqing/.gitkeep` which completed successfully to allow repository tracking of the folder.
- Attempted a local site build with `bundle exec jekyll build --quiet` which failed due to the environment missing the `jekyll` executable (build not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37e8da4f8832fbbe553f18456798c)