### PR TITLE
Update Guangzhou 2026 gallery with images 10 and 11

### DIFF
--- a/_projects/10_project.md
+++ b/_projects/10_project.md
@@ -27,3 +27,5 @@ images:
 <a href="../../assets/img/2026guangzhou/7.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/7.jpg" /></a>
 <a href="../../assets/img/2026guangzhou/8.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/8.jpg" /></a>
 <a href="../../assets/img/2026guangzhou/9.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/9.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/10.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/10.jpg" /></a>
+<a href="../../assets/img/2026guangzhou/11.jpg" data-lightbox="roadtrip"><img src="../../assets/img/2026guangzhou/thumbs/11.jpg" /></a>


### PR DESCRIPTION
### Motivation
- 新上传的 `assets/img/2026guangzhou/10.jpg` 和 `11.jpg` 需要在大会相册页面中展示并与对应缩略图配对以保持画廊一致性。

### Description
- 在 `_projects/10_project.md` 的图片画廊中添加了两行 lightbox 链接，分别指向 `assets/img/2026guangzhou/10.jpg` 和 `assets/img/2026guangzhou/11.jpg`，并使用对应的 `thumbs/10.jpg` 与 `thumbs/11.jpg` 缩略图。

### Testing
- 已使用 `git diff -- _projects/10_project.md` 和 `nl -ba _projects/10_project.md | sed -n '18,40p'` 验证变更，且已成功提交（1 file changed, 2 insertions(+)。）

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d9168344832fa29e7a4b128ec42a)