### PR TITLE
Add fun gallery page for 2026-04-28 bowling activity

### DIFF
--- a/_projects/12_project.md
+++ b/_projects/12_project.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: 海淀区西郊宾馆保龄球
+description: 2026年4月28日 北京 海淀区西郊宾馆
+event_date: 2026-04-28
+img: assets/img/20260428-bowling/1.jpg
+importance: 1
+category: fun
+related_publications: false
+images:
+  lightbox2: true
+  photoswipe: true
+  spotlight: true
+  venobox: true
+---
+
+2026年4月28日，课题组在北京市海淀区西郊宾馆组织了一次保龄球活动。大家暂时放下科研任务，在球道上比拼手感与默契，现场气氛轻松又热烈。
+
+从热身练习到正式“开打”，每一次全中和补中都会引来一阵欢呼；有人稳扎稳打、节奏沉稳，也有人后来居上、连续得分。活动结束后，大家纷纷表示这是一次很解压、很有凝聚力的集体活动。
+
+## 保龄球活动照片（点击图片放大）
+
+<a href="../../assets/img/20260428-bowling/1.jpg" data-lightbox="roadtrip"><img src="../../assets/img/20260428-bowling/1.jpg" /></a>
+<a href="../../assets/img/20260428-bowling/2.jpg" data-lightbox="roadtrip"><img src="../../assets/img/20260428-bowling/2.jpg" /></a>
+<a href="../../assets/img/20260428-bowling/3.jpg" data-lightbox="roadtrip"><img src="../../assets/img/20260428-bowling/3.jpg" /></a>
+<a href="../../assets/img/20260428-bowling/4.jpg" data-lightbox="roadtrip"><img src="../../assets/img/20260428-bowling/4.jpg" /></a>
+<a href="../../assets/img/20260428-bowling/5.jpg" data-lightbox="roadtrip"><img src="../../assets/img/20260428-bowling/5.jpg" /></a>


### PR DESCRIPTION
### Motivation
- Record a lab social event (group bowling at Xijiao Hotel, Haidian) as a `fun` gallery entry on the site to surface team activities.
- Provide a ready-to-use gallery scaffold so uploaded images will display immediately without further template changes.

### Description
- Added a new project post at `_projects/12_project.md` with frontmatter (title, `event_date`, `category: fun`, `img` thumbnail) and a Chinese event recap.
- Included a 5-image gallery scaffold using numeric filenames `1.jpg`–`5.jpg` and lightbox links in the post body so images open in-place when present.
- Created the image directory `assets/img/20260428-bowling/` and added a placeholder file `assets/img/20260428-bowling/.gitkeep` to preserve the folder in the repository.

### Testing
- Verified the new file content with `nl -ba _projects/12_project.md`, which showed the expected frontmatter and gallery links.
- Performed a repository status check with `git status --short` to ensure the new files are present, which succeeded.
- Created the PR via the internal tooling (`make_pr`), and the PR metadata was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16ddb27fc832f9ae8c667610df3ed)