### PR TITLE
fix: add 团建 prefix to bowling fun page title

### DIFF
--- a/_projects/12_project.md
+++ b/_projects/12_project.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 海淀区西郊宾馆保龄球
+title: 团建 海淀区西郊宾馆保龄球
 description: 2026年4月28日 北京 海淀区西郊宾馆
 event_date: 2026-04-28
 img: assets/img/20260428-bowling/thumbs/1.jpg


### PR DESCRIPTION
### Motivation
- Ensure naming consistency for `category: fun` posts by adding the `团建` prefix to the bowling activity title.

### Description
- Update front matter in `_projects/12_project.md` by changing `title: 海淀区西郊宾馆保龄球` to `title: 团建 海淀区西郊宾馆保龄球`.

### Testing
- No automated tests were run because this is a content-only markdown metadata update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1750eb550832fa971d4dcede339a7)