### PR TITLE
Add June 2026 WeChat recognition entry to teaching page

### DIFF
--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -13,6 +13,7 @@ nav_order: 4
     * 4月14日：担任本科毕业设计中期答辩A4组评委（组长：宋文凤；组员：刘晓彤、闫荣）；答辩学生：白曼昀、王祎晨、周俊杰、郑丁宁、闫志豪、殷科鹏、李嘉诚、卢国红、张皓
     * 5月10日：[参加2026年本科招生咨询，面向考生与家长介绍学院专业设置、培养特色与升学就业情况，并进行现场答疑](https://mp.weixin.qq.com/s/7pYSaYOEFpTN1VmBNytdig)；活动照片：[图1](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun.jpg)、[图2](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun1.jpg)、[图3](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun2.jpg)、[图4](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun3.jpg)
     * 6月1日：担任本科毕设答辩组（软工4组，XXB-206）组长，组员：杨涛老师，赵淳老师；答辩学生：陈逸龙、杨楠、吴文静、姜岸岑、马梓旭、徐欣悦、何祎凡、张恩浦、白雨轩、赵若涵、牛岳峰、白曼昀、王文希、王瀚文、冯建国、王艳茹、冶欣亚
+    * 6月：[获评财务处微信公众号“报销达人”](https://mp.weixin.qq.com/s/5NJ_yWpD1P0mTnqdUnJ1MQ)
   * 研究生：
     * 2月12日：担任硕士开题答辩组(第13组)答辩评委；答辩学生：李金峰、张华威、肖智钰、袁鹏辉、毛源源、高建、李欣、刘震宇、金璐洁、李彬、李兆伟、王乐乐
     * 4-6月：AI驱动的材料与化学（CS521）


### PR DESCRIPTION
### Motivation
- Record a new recognition received in June 2026 on the Teaching page, so the timeline reflects the award from the Finance Office WeChat account (“报销达人”).

### Description
- Added a single bullet under `2026` → `本科生` for June linking to the WeChat article: `https://mp.weixin.qq.com/s/5NJ_yWpD1P0mTnqdUnJ1MQ`.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fbd36be70832fb08aa333d39e804e)