### PR TITLE
Fix bachelor alumni photo alignment

### DIFF
--- a/_pages/profiles_bachelor_alumni.md
+++ b/_pages/profiles_bachelor_alumni.md
@@ -9,7 +9,7 @@ nav_order: 6
 profiles:
   # if you want to include more than one profile, just replicate the following block
   # and create one content file for each profile inside _pages/
-  - align: right
+  - align: left
     image: people_pics/2026bishe.jpg
     content: people/2026_bishe.md
     image_circular: false # crops the image to make it circular


### PR DESCRIPTION
### Motivation
- Ensure the graduated undergraduate profile photos alternate left/right starting from the top so the list is `left`, `right`, `left`, `right` rather than beginning with the wrong side.

### Description
- Changed the first profile's `align` value from `right` to `left` in `_pages/profiles_bachelor_alumni.md` to restore the intended alternating layout.

### Testing
- `git diff --check` was run and reported no issues.
- `bundle exec jekyll build` was attempted but failed locally with `bundler: command not found: jekyll`, indicating the Jekyll executable is not available in the environment (install with `bundle install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38e9a0217c832fa4187f3e88e0dd72)