### PR TITLE
Add 2026 graduate gallery

### DIFF
--- a/_projects/13_project.md
+++ b/_projects/13_project.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title: 2026
+description: 2026年6月24日 北信科小营校区
+event_date: 2026-06-24
+img: assets/img/graduates/2026/cover.svg
+importance: -3
+category: graduates
+related_publications: false
+images:
+  lightbox2: true
+  photoswipe: true
+  spotlight: true
+  venobox: true
+---
+
+2026年6月24日，小营校区毕业合影。
+
+照片上传文件夹：`assets/img/graduates/2026/`
+
+## 集体合影（点击图片放大）
+
+{% assign graduate_2026_files = site.static_files | where_exp: "file", "file.path contains '/assets/img/graduates/2026/'" | sort: "name" %}
+{% assign graduate_2026_count = 0 %}
+
+{% for photo in graduate_2026_files %}
+{% unless photo.path contains '/thumbs/' %}
+{% if photo.extname == '.jpg' or photo.extname == '.jpeg' or photo.extname == '.png' or photo.extname == '.webp' or photo.extname == '.gif' %}
+{% assign graduate_2026_count = graduate_2026_count | plus: 1 %}
+<a href="{{ photo.path | relative_url }}" data-lightbox="roadtrip"><img src="{{ photo.path | relative_url }}" /></a>
+{% endif %}
+{% endunless %}
+{% endfor %}
+
+{% if graduate_2026_count == 0 %}
+照片待上传。请把照片放到 `assets/img/graduates/2026/`，页面会自动列出该文件夹下的 jpg、jpeg、png、webp、gif 图片。
+{% endif %}

--- a/assets/img/graduates/2026/cover.svg
+++ b/assets/img/graduates/2026/cover.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800" role="img" aria-label="2026 graduates album placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#e8f3ff"/>
+      <stop offset="100%" stop-color="#fff1e6"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)"/>
+  <circle cx="240" cy="190" r="95" fill="#9dccff" opacity="0.65"/>
+  <circle cx="970" cy="610" r="130" fill="#ffc48c" opacity="0.55"/>
+  <rect x="180" y="200" width="840" height="450" rx="36" fill="#ffffff" opacity="0.88"/>
+  <text x="600" y="365" text-anchor="middle" font-family="Arial, 'Noto Sans SC', sans-serif" font-size="112" font-weight="700" fill="#2f5d8c">2026</text>
+  <text x="600" y="455" text-anchor="middle" font-family="Arial, 'Noto Sans SC', sans-serif" font-size="44" fill="#5f6f7e">毕业合影 · 小营校区</text>
+  <text x="600" y="525" text-anchor="middle" font-family="Arial, 'Noto Sans SC', sans-serif" font-size="32" fill="#8492a6">照片待上传</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Add a new Gallery entry for the 2026 graduates (2026-06-24, Xiaoying campus) so photos can be uploaded and displayed like prior years.
- Provide an upload folder and placeholder cover so the gallery card has a cover before photos are uploaded.

### Description
- Added a new project page `_projects/13_project.md` with Jekyll front-matter for the 2026 graduates and Liquid code that automatically lists images from `assets/img/graduates/2026/` (filters out `thumbs/` and only includes `.jpg/.jpeg/.png/.webp/.gif`).
- Added a placeholder cover image `assets/img/graduates/2026/cover.svg` to show on the Gallery card before photos are uploaded.
- Created `assets/img/graduates/2026/thumbs/.gitkeep` so the thumbs directory is tracked and ready for generated thumbnails.
- No configuration changes to collections; the new page uses the existing `graduates` category and will appear in the Gallery listing.

### Testing
- Ran `bundle install`, which completed successfully.
- Ran `bundle exec jekyll build`, which failed due to external feed/Twitter requests returning `403 Forbidden` from external sources.
- Ran `bundle exec jekyll build --config _config.yml,/tmp/no_external.yml` (external sources disabled), which still failed because ImageMagick `convert` is not available in the environment and some external Twitter embeds returned `403`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b47d0b588832f982b5eb58f217566)