### PR TITLE
Use thumbnail for 2026 graduation album

### DIFF
--- a/_projects/13_project.md
+++ b/_projects/13_project.md
@@ -3,7 +3,7 @@ layout: post
 title: 2026
 description: 2026年6月24日 北信科小营校区
 event_date: 2026-06-24
-img: assets/img/graduates/2026/cdfae1c8ad0d4281f37b640ac7a075b6.jpg
+img: assets/img/graduates/2026/thumbs/1.jpg
 importance: -3
 category: graduates
 related_publications: false
@@ -18,4 +18,4 @@ images:
 
 ## 集体合影（点击图片放大）
 
-<a href="../../assets/img/graduates/2026/cdfae1c8ad0d4281f37b640ac7a075b6.jpg" data-lightbox="roadtrip"><img src="../../assets/img/graduates/2026/cdfae1c8ad0d4281f37b640ac7a075b6.jpg" /></a>
+<a href="../../assets/img/graduates/2026/cdfae1c8ad0d4281f37b640ac7a075b6.jpg" data-lightbox="roadtrip"><img src="../../assets/img/graduates/2026/thumbs/1.jpg" /></a>


### PR DESCRIPTION
### Motivation
- Use the uploaded thumbnail at `assets/img/graduates/2026/thumbs/1.jpg` for the album cover and inline preview to match other graduate albums and reduce page load while preserving the full-size image for lightbox viewing.

### Description
- Updated `_projects/13_project.md` to set `img:` to `assets/img/graduates/2026/thumbs/1.jpg` and changed the inline `<img src="...">` to the thumbnail while keeping the `<a href="...">` pointing to the full-size image.

### Testing
- Ran `bundle exec jekyll build`, which failed with `bundler: command not found: jekyll` indicating dependencies need `bundle install` (no successful build performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b55788a74832fb81074253e97e830)