### PR TITLE
Add ORCID link to publications page

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,7 +2,7 @@
 layout: page
 permalink: /publications/
 title: Publications
-description: Full list in <a href='https://scholar.google.com/citations?hl=zh-CN&user=rTKMeoAAAAAJ&view_op=list_works&sortby=pubdate'><u>`google scholar`</u></a> 
+description: Full list in <a href='https://scholar.google.com/citations?hl=zh-CN&user=rTKMeoAAAAAJ&view_op=list_works&sortby=pubdate'><u>`google scholar`</u></a> and <a href='https://orcid.org/0000-0001-7755-2530'><u>`ORCID`</u></a>
 nav: true
 nav_order: 1
 ---


### PR DESCRIPTION
### Motivation
- Make the Publications page include the author's ORCID so ORCID-based records (including review information and future publications) are linked and visible alongside the existing Google Scholar link (`https://orcid.org/0000-0001-7755-2530`).

### Description
- Updated `_pages/publications.md` to append an ORCID link next to the existing Google Scholar link in the page `description` front-matter.

### Testing
- Ran `bundle install` successfully, but `bundle exec jekyll build` could not complete due to `403 Forbidden` responses when fetching configured external posts, and a build with external sources disabled (`bundle exec jekyll build --config /tmp/jekyll_no_external.yml`) also failed for the same reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a449bc10818832fbdc524ff75bfa9f0)