### PR TITLE
Fix JPCL cover image reference

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -293,7 +293,7 @@ selected={False}
 }
 
 @article{yang2026jpclett,
-  preview={jpclett-5c03985-cover.png},
+  preview={jpclcd.2026.17.issue-7.largecover.webp},
   title={Data-Driven Deciphering Structure--M{\"o}ssbauer Spectroscopy Relationships in Iron-Based Compounds},
   author={Yang, Tao and Zhang, Jiaqing and Chen, Haotian and Yuan, Xiaoze and Zhou, Yuwei and Guo, Wenping and Liu, Xingchen and Liu, Xiaotong and Liu, Jinjia},
   journal={The Journal of Physical Chemistry Letters},


### PR DESCRIPTION
### Motivation
- Replace an incorrect JPCL article preview image reference with the newly uploaded `jpclcd.2026.17.issue-7.largecover.webp` so the publication preview shows the correct cover.

### Description
- Updated the `preview` field for the `@article{yang2026jpclett}` entry in `_bibliography/papers.bib` from `jpclett-5c03985-cover.png` to `jpclcd.2026.17.issue-7.largecover.webp`.

### Testing
- Ran `git diff --check`, which reported no whitespace/errors.
- Ran `bundle exec jekyll build`, which failed due to a `403 Forbidden` response when fetching external Medium RSS in `_plugins/external-posts.rb` (external service/environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f7c1ea820832fab6f8deffa6577b4)