### PR TITLE
Add JCIM publication (selected) with placeholder cover

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,5 +1,25 @@
 @string{aps = {American Physical Society,}}
 
+
+@article{lai2026familywise,
+  preview={jcim_placeholder.svg},
+  title={Familywise Feature Importance Stability in Chemical and Materials Machine Learning},
+  author={Lai, Ruilin and Liu, Xiaotong and Wang, Yuhang and Rignanese, Gian-Marco and Li, Wei-Xue},
+  journal={Journal of Chemical Information and Modeling},
+  year={2026},
+  month={jul},
+  day={16},
+  publisher={American Chemical Society},
+  doi={10.1021/acs.jcim.6c00893},
+  url={https://pubs.acs.org/doi/abs/10.1021/acs.jcim.6c00893},
+  html={https://pubs.acs.org/doi/abs/10.1021/acs.jcim.6c00893},
+  abstract={While feature importance analysis in chemical and materials machine learning can often be sensitive to both the predictive model and the attribution rule, the robustness of these rankings is rarely quantified before they are used to gain physical insights. Here, we compare 26 feature importance pipelines spanning data-driven, model-based, and formula-based analyses on a metal--support interaction data set anchored by an explicit SISSO equation, and we examine whether the same qualitative behavior recurs in high-entropy-alloy and halide perovskite data sets. Across the three benchmarks, we observe high intrafamily agreement but substantial interfamily variance. While a small subset of features remains stable across multiple families, several midranked features are highly family dependent, with their apparent importance shifting according to the underlying modeling assumptions. To ensure robust interpretability, we recommend that feature importance be reported by method family or correlation-based clusters, supplemented by resampling intervals.},
+  keywords={Feature importance, Interpretable machine learning, Materials machine learning, Chemical machine learning},
+  altmetric={true},
+  dimensions={true},
+  selected={true}
+}
+
 @article{liu2026cmt,
   preview={computational_materials_today_2026.jpg},
   title={A review of topological descriptors for amorphous materials complementing graph neural networks},

--- a/assets/img/publication_preview/jcim_placeholder.svg
+++ b/assets/img/publication_preview/jcim_placeholder.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">JCIM publication placeholder</title>
+  <desc id="desc">Placeholder cover art for a Journal of Chemical Information and Modeling publication.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="55%" stop-color="#1e3a8a"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="70%" cy="30%" r="55%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#f8fafc" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <rect width="1200" height="675" fill="url(#glow)"/>
+  <g opacity="0.35" stroke="#bfdbfe" stroke-width="4" fill="none">
+    <path d="M155 470 C315 240 470 575 630 330 S930 210 1050 455"/>
+    <path d="M170 205 C310 335 425 120 560 250 S835 560 1040 215"/>
+  </g>
+  <g fill="#f8fafc" opacity="0.92">
+    <circle cx="180" cy="460" r="22"/>
+    <circle cx="330" cy="265" r="17"/>
+    <circle cx="500" cy="520" r="19"/>
+    <circle cx="650" cy="320" r="24"/>
+    <circle cx="835" cy="275" r="16"/>
+    <circle cx="1035" cy="455" r="21"/>
+    <circle cx="255" cy="255" r="15"/>
+    <circle cx="445" cy="160" r="20"/>
+    <circle cx="790" cy="520" r="18"/>
+    <circle cx="1010" cy="215" r="16"/>
+  </g>
+  <g font-family="Arial, Helvetica, sans-serif" fill="#ffffff">
+    <text x="90" y="155" font-size="64" font-weight="700">Journal of Chemical</text>
+    <text x="90" y="225" font-size="64" font-weight="700">Information and Modeling</text>
+    <text x="90" y="305" font-size="38" opacity="0.9">Publication cover placeholder</text>
+    <text x="90" y="585" font-size="46" font-weight="700">Feature Importance Stability</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Add a recently published Journal of Chemical Information and Modeling article (DOI 10.1021/acs.jcim.6c00893) to the site's publications so it will appear in the bibliography and on the homepage. 
- Mark the entry as selected so it is shown in the homepage selected papers area and provide a temporary cover until the final image is uploaded.

### Description
- Insert a new BibTeX entry `@article{lai2026familywise,...}` into `_bibliography/papers.bib` containing title, authors, journal, DOI, ACS URL, abstract, keywords and metadata and set `selected={true}`. 
- Add a temporary SVG preview `assets/img/publication_preview/jcim_placeholder.svg` and reference it via `preview={jcim_placeholder.svg}` in the BibTeX entry. 
- Ensure the entry includes `altmetric`/`dimensions` flags so it integrates with the existing publication rendering.

### Testing
- `bundle install` was run and completed successfully. 
- `bundle exec ruby -rbibtex -e 'BibTeX.open("_bibliography/papers.bib"); puts "BibTeX parsed"'` completed successfully and parsed the bibliography. 
- `bundle exec jekyll build` was attempted but failed due to external HTTP 403 responses when fetching external feeds (Medium) and a Twitter embed 403 during site generation. 
- A subsequent build with external sources disabled still encountered image processing failures because ImageMagick `convert` is missing in the environment, preventing generation of site thumbnails and webp derivatives.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f7e1c22ac832f8b94cb40fc0146b9)