### PR TITLE
Update Lai et al. (2026) bibliography entry with final metadata and preview image

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2,13 +2,16 @@
 
 
 @article{lai2026familywise,
-  preview={jcim_placeholder.svg},
+  preview={jcim2026.jpeg},
   title={Familywise Feature Importance Stability in Chemical and Materials Machine Learning},
   author={Lai, Ruilin and Liu, Xiaotong and Wang, Yuhang and Rignanese, Gian-Marco and Li, Wei-Xue},
   journal={Journal of Chemical Information and Modeling},
+  volume={66},
+  number={14},
+  pages={7996--8007},
   year={2026},
   month={jul},
-  day={16},
+  day={27},
   publisher={American Chemical Society},
   doi={10.1021/acs.jcim.6c00893},
   url={https://pubs.acs.org/doi/abs/10.1021/acs.jcim.6c00893},


### PR DESCRIPTION
### Motivation
- Provide accurate publication metadata and a final preview image for the `lai2026familywise` bibliography entry to reflect the published Journal of Chemical Information and Modeling record.

### Description
- Update the `lai2026familywise` entry by replacing `preview={jcim_placeholder.svg}` with `preview={jcim2026.jpeg}`, adding `volume`, `number`, and `pages`, and adjusting the `day` field to the final publication date.

### Testing
- No automated tests were run for this bibliography-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67e249d254832f933edebc1c6e6dad)