### PR TITLE
Move 陈昊天 & 蒋冰鉴 to master alumni pages

### DIFF
--- a/_pages/profiles_master_alumni.md
+++ b/_pages/profiles_master_alumni.md
@@ -34,4 +34,17 @@ profiles:
     image_circular: false # crops the image to make it circular
     more_info: >
       <p>计研2403</p>
+  - align: left
+    image: people_pics/cht_profile_picture.png
+    content: people/cht_profile.md
+    image_circular: false # crops the image to make it circular
+    more_info: >
+      <p>计研2301</p>
+  - align: right
+    image: people_pics/jbj_profile_picture.png
+    content: people/jbj_profile.md
+    image_circular: false # crops the image to make it circular
+    more_info: >
+      <p>计研2301</p>
+      <p>与杨涛老师合作指导</p>
 ---

--- a/_pages/profiles_master_present.md
+++ b/_pages/profiles_master_present.md
@@ -10,19 +10,6 @@ profiles:
   # if you want to include more than one profile, just replicate the following block
   # and create one content file for each profile inside _pages/
   - align: left
-    image: people_pics/cht_profile_picture.png
-    content: people/cht_profile.md
-    image_circular: false # crops the image to make it circular
-    more_info: >
-      <p>计研2301</p>
-  - align: right
-    image: people_pics/jbj_profile_picture.png
-    content: people/jbj_profile.md
-    image_circular: false # crops the image to make it circular
-    more_info: >
-      <p>计研2301</p>
-      <p>与杨涛老师合作指导</p>
-  - align: left
     image: people_pics/wyh_profile_picture.png
     content: people/wyh_profile.md
     image_circular: false # crops the image to make it circular


### PR DESCRIPTION
### Motivation

- 陈昊天和蒋冰鉴已毕业，需要从“在读硕士生”栏目移到“已毕业硕士生”栏目并保留他们的资料与照片。 
- 页面展示应保持左右交替的排版风格，因此调整必须维护 `left` / `right` 交替顺序。 

### Description

- 从 ` _pages/profiles_master_present.md` 中删除了两位同学的 profile 块。 
- 将对应的 profile 块按顺序追加到 ` _pages/profiles_master_alumni.md`，其中陈昊天为 `left`，蒋冰鉴为 `right`，并保留原有 `image`、`content` 和 `more_info` 字段。 
- 确认两个页面的 `profiles` 数组保持左/右交替布局。 
- 提交已保存为说明为 `Move graduated students to master alumni` 的提交（`618145e`）。

### Testing

- 运行 `npx prettier --check _pages/profiles_master_present.md _pages/profiles_master_alumni.md`，格式检查通过。 
- 运行 `git diff --check`，无差错输出。 
- 运行自定义 YAML 校验脚本（验证 `profiles` 的 `align` 列表为 `left -> right -> left -> ...`），两个页面均通过验证。 
- 尝试运行 `bundle exec jekyll build` 未能执行，因为当前环境缺少可用的 Jekyll 可执行文件（非代码错误）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a93731dcbc0832fad7504376fc5dd24)