### PR TITLE
Add latest WeChat media coverage to news and homepage

### DIFF
--- a/_news/announcement_7.md
+++ b/_news/announcement_7.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-08-30 10:00:00-0400
+inline: true
+related_posts: false
+---
+
+<a href='https://mp.weixin.qq.com/s/ASYlgpLYUAibTEzfKoHysg'>Recent media coverage featuring Xiaotong Liu</a>


### PR DESCRIPTION
### Motivation
- Surface a newly published media report (WeChat article) as a site news announcement and ensure it appears on the homepage news module.

### Description
- Add a new inline news post file `_news/announcement_7.md` containing the provided WeChat link and front matter (`layout: post`, `inline: true`, `related_posts: false`).
- The change leverages the existing `news` collection and announcements configuration so the item is shown on both the `/news/` page and the homepage news section.
- The file was added and committed to the repository so the site will include the announcement on the next deployment.

### Testing
- `git diff --check` was run and reported no issues, indicating the patch is syntactically clean.
- `bundle exec jekyll build --config _config.yml,/tmp/jekyll-offline.yml` was executed using an offline override to skip remote RSS/Twitter embeds and completed with expected warnings (image-processing tools missing) while producing generated HTML.
- `rg -n "Recent media coverage featuring Xiaotong Liu|ASYlgpLYUAibTEzfKoHysg" _site/index.html _site/news/index.html` confirmed the new link appears in both the generated homepage and news page HTML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9378bfba3c832f8c1f3ea62b42046a)