### PR TITLE
Add 9 Sep 2026 honor-college interview entry to Teaching page

### DIFF
--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -14,6 +14,7 @@ nav_order: 4
     * 5月10日：[参加2026年本科招生咨询，面向考生与家长介绍学院专业设置、培养特色与升学就业情况，并进行现场答疑](https://mp.weixin.qq.com/s/7pYSaYOEFpTN1VmBNytdig)；活动照片：[图1](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun.jpg)、[图2](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun1.jpg)、[图3](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun2.jpg)、[图4](/assets/img/20260510_gaozhaozixun/20260510gaozhaozixun3.jpg)
     * 6月1日：担任本科毕设答辩组（软工4组，XXB-206）组长，组员：杨涛老师，赵淳老师；答辩学生：陈逸龙、杨楠、吴文静、姜岸岑、马梓旭、徐欣悦、何祎凡、张恩浦、白雨轩、赵若涵、牛岳峰、白曼昀、王文希、王瀚文、冯建国、王艳茹、冶欣亚
     * 6月：[获评财务处微信公众号“报销达人”](https://mp.weixin.qq.com/s/5NJ_yWpD1P0mTnqdUnJ1MQ)
+    * 9月2日：担任勤信荣誉学院校内遴选面试考官
   * 研究生：
     * 2月12日：担任硕士开题答辩组(第13组)答辩评委；答辩学生：李金峰、张华威、肖智钰、袁鹏辉、毛源源、高建、李欣、刘震宇、金璐洁、李彬、李兆伟、王乐乐
     * 4-6月：AI驱动的材料与化学（CS521）


### PR DESCRIPTION
### Motivation
- Record a recent undergraduate service (2026-09-02) on the site's `Teaching` page so the teaching activities are up to date.

### Description
- Added one line under `2026` → `本科生` in `_pages/teaching.md`: `* 9月2日：担任勤信荣誉学院校内遴选面试考官`, and committed the change with message `Add 2026 honor college interview service`.

### Testing
- Verified front matter and Markdown rendering and confirmed the new entry is present using a `ruby`/Kramdown check (`ruby -e ...Kramdown::Document.new(...)`) and ran `git diff --check`, both of which passed; a full `bundle exec jekyll build` could not complete in this environment due to external-service HTTP 403 errors (external posts / Twitter plugin) and missing ImageMagick, so site build failed here; the change was committed and the working tree is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98b3f218fc832f8d59b428b31ba4f7)