### PR TITLE
Increase homepage news limit to 5 and add latest media coverage announcement

### DIFF
--- a/_news/announcement_8.md
+++ b/_news/announcement_8.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-09-03 10:00:00-0400
+inline: true
+related_posts: false
+---
+
+<a href='https://mp.weixin.qq.com/s/krIalUwjGh8EbhF3ghAPiA'>Latest media coverage featuring Xiaotong Liu</a>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -17,7 +17,7 @@ profile:
 
 announcements:
   enabled: true
-  limit: 3
+  limit: 5
 news: true  # includes a list of news items
 latest_posts: false  # includes a list of the newest posts
 selected_papers: true # includes a list of papers marked as "selected={true}"


### PR DESCRIPTION
### Motivation
- Make the homepage show up to five news items and surface a new media report by adding the provided WeChat link as an inline announcement.

### Description
- Update `announcements.limit` from `3` to `5` in `_pages/about.md` and add a new inline news post at `_news/announcement_8.md` linking to the WeChat article.

### Testing
- Ran `bundle install` which completed successfully. 
- Ran `bundle exec jekyll build` and observed an initial failure due to external RSS/Twitter requests returning HTTP 403, then rebuilt with external sources disabled (using an override config) which completed but produced ImageMagick warnings because `convert` is not available in the environment. 
- Verified the generated `_site/index.html` contains five news rows with the new announcement as the most recent item.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a04b535ac832fbf40caaadc1c64c3)