### PR TITLE
Add announcement linking to BISTU News coverage of Xiaotong Liu

### DIFF
--- a/_news/announcement_9.md
+++ b/_news/announcement_9.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-03-02 10:00:00-0400
+inline: true
+related_posts: false
+---
+
+<a href='https://news.bistu.edu.cn/jjxy/8abf8ed6402540228122feb1546cfe55.html'>BISTU News coverage featuring Xiaotong Liu</a>


### PR DESCRIPTION
### Motivation
- Add an inline news announcement to reference external BISTU News coverage featuring Xiaotong Liu.

### Description
- Create ` _news/announcement_9.md` with Jekyll front matter and a link to the BISTU News article.

### Testing
- No automated tests were run because this is a content-only addition and does not modify code or CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a10b84a54832fb90511a5b2874f45)